### PR TITLE
feat: Add Serial Transmission Support

### DIFF
--- a/config/network_config.yaml
+++ b/config/network_config.yaml
@@ -53,3 +53,21 @@ outputs:
     broadcast: true
     send_timeout: 1.0
 
+  - type: serial
+    enabled: true # Set to false to disable this output
+    port: "/dev/ttyUSB0"  # Example for Linux. Windows: "COM1", macOS: "/dev/cu.usbserial-XYZ"
+    baudrate: 9600
+    bytesize: "EIGHTBITS" # Or 5, 6, 7, "FIVEBITS", "SIXBITS", "SEVENBITS"
+    parity: "PARITY_NONE" # Or "PARITY_EVEN", "PARITY_ODD", "PARITY_MARK", "PARITY_SPACE"
+    stopbits: "STOPBITS_ONE" # Or 1.5, 2, "STOPBITS_ONE_POINT_FIVE", "STOPBITS_TWO"
+    timeout: 1.0          # Read timeout in seconds (float or null)
+    write_timeout: 1.0    # Write timeout in seconds (float or null)
+    # Optional settings:
+    # rtscts: false         # Enable RTS/CTS hardware flow control
+    # dsrdtr: false         # Enable DSR/DTR hardware flow control
+    # xonxoff: false        # Enable XON/XOFF software flow control
+    # exclusive: true       # Request exclusive access to the port (POSIX only)
+    # send_interval: 0.0    # Minimum seconds between sends (0 for no delay)
+    # reconnect_delay: 5.0  # Seconds to wait before trying to reconnect
+    # max_reconnect_attempts: 5 # Number of reconnect attempts (-1 for infinite)
+    # line_ending: "\r\n"   # Characters to append to each NMEA sentence (e.g., "\n", "\r\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ typing-extensions>=4.0.0
 
 # Networking and async
 asyncio-mqtt>=0.11.0
+pyserial>=3.5
 
 # Development dependencies
 pytest>=7.0.0

--- a/simulator/outputs/base.py
+++ b/simulator/outputs/base.py
@@ -1,7 +1,7 @@
 """Base output handler for NMEA sentences."""
 
 from abc import ABC, abstractmethod
-from datetime import datetime
+import time # Changed from datetime to time
 from typing import Dict, Any
 
 
@@ -12,8 +12,9 @@ class OutputHandler(ABC):
         """Initialize output handler."""
         self.is_running = False
         self.sentences_sent = 0
-        self.start_time: datetime = datetime.now()
-        self.last_sentence_time: datetime = datetime.now()
+        # Changed to use time.time() for consistency with other modules
+        self.start_time: float = time.time()
+        self.last_sentence_time: float = time.time()
     
     @abstractmethod
     def start(self) -> None:
@@ -40,22 +41,24 @@ class OutputHandler(ABC):
     
     def get_status(self) -> Dict[str, Any]:
         """Get output handler status information."""
-        now = datetime.now()
-        uptime = (now - self.start_time).total_seconds() if self.is_running else 0
+        current_time = time.time()
+        uptime = (current_time - self.start_time) if self.is_running and self.start_time else 0
         
         return {
             'running': self.is_running,
             'sentences_sent': self.sentences_sent,
             'uptime_seconds': uptime,
-            'last_sentence_time': self.last_sentence_time.isoformat(),
-            'sentences_per_second': self.sentences_sent / max(1, uptime)
+            # Convert timestamp to ISO format string, or None if not set
+            'last_sentence_time': time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(self.last_sentence_time)) if self.last_sentence_time else None,
+            'sentences_per_second': self.sentences_sent / max(1, uptime) if uptime > 0 else 0
         }
     
     def reset_stats(self) -> None:
         """Reset statistics."""
         self.sentences_sent = 0
-        self.start_time = datetime.now()
-        self.last_sentence_time = datetime.now()
+        current_time = time.time()
+        self.start_time = current_time
+        self.last_sentence_time = current_time
     
     def __enter__(self):
         """Context manager entry."""

--- a/simulator/outputs/factory.py
+++ b/simulator/outputs/factory.py
@@ -5,6 +5,7 @@ from .base import OutputHandler
 from .file import FileOutput
 from .tcp import TCPOutput
 from .udp import UDPOutput
+from .serial_output import SerialOutput # Added import
 from ..config.parser import OutputConfig
 
 
@@ -23,6 +24,8 @@ class OutputFactory:
             return TCPOutput(output_config.config)
         elif output_config.type == 'udp':
             return UDPOutput(output_config.config)
+        elif output_config.type == 'serial': # Added serial type
+            return SerialOutput(output_config.config)
         else:
             raise ValueError(f"Unknown output type: {output_config.type}")
     

--- a/simulator/outputs/serial_output.py
+++ b/simulator/outputs/serial_output.py
@@ -1,0 +1,283 @@
+"""Serial output handler for NMEA sentences."""
+
+from dataclasses import dataclass, field
+from typing import Optional # Added Optional
+import serial
+
+@dataclass
+class SerialOutputConfig:
+    """Configuration for Serial output."""
+
+    port: str = "/dev/ttyS0"  # Default serial port
+    baudrate: int = 9600
+    bytesize: serial.SerialBytesize = serial.EIGHTBITS
+    parity: serial.SerialParity = serial.PARITY_NONE
+    stopbits: serial.SerialStopbits = serial.STOPBITS_ONE
+    timeout: Optional[float] = 1.0  # Read timeout
+    write_timeout: Optional[float] = 1.0 # Write timeout
+    rtscts: bool = False
+    dsrdtr: bool = False
+    xonxoff: bool = False
+    exclusive: bool = True # Exclusive access to the port
+    send_interval: float = 0.1 # Minimum interval between sends, in seconds
+    reconnect_delay: float = 5.0 # Delay before attempting to reconnect, in seconds
+    max_reconnect_attempts: int = 5 # Maximum number of reconnect attempts (-1 for infinite)
+    line_ending: str = "\r\n" # Characters to append to each sentence
+
+    # Fields for pyserial-specific settings that might not be common
+    # These are advanced settings and might not be needed for basic operation
+    # For example: inter_byte_timeout, dsr_timeout, rts_level, cts_level
+    # serial_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        # Validate common settings
+        if not self.port:
+            raise ValueError("Serial port must be specified.")
+        if self.baudrate <= 0:
+            raise ValueError("Baudrate must be a positive integer.")
+        if self.timeout is not None and self.timeout < 0:
+            raise ValueError("Timeout cannot be negative.")
+        if self.write_timeout is not None and self.write_timeout < 0:
+            raise ValueError("Write timeout cannot be negative.")
+
+        # Convert string representations of serial settings to their pyserial equivalents
+        # This allows configuration from YAML/JSON using strings like "EIGHTBITS", "PARITY_ODD", etc.
+        if isinstance(self.bytesize, str):
+            self.bytesize = getattr(serial, self.bytesize.upper(), serial.EIGHTBITS)
+        if isinstance(self.parity, str):
+            self.parity = getattr(serial, f"PARITY_{self.parity.upper()}", serial.PARITY_NONE)
+        if isinstance(self.stopbits, str):
+            self.stopbits = getattr(serial, f"STOPBITS_{self.stopbits.upper().replace('.', '_')}", serial.STOPBITS_ONE)
+
+        # Line ending validation
+        if not isinstance(self.line_ending, str):
+            raise ValueError("Line ending must be a string (e.g., '\\r\\n', '\\n').")
+        try:
+            self.line_ending.encode('ascii') # Check if it's valid ASCII
+        except UnicodeEncodeError:
+            raise ValueError("Line ending contains non-ASCII characters.")
+
+    def get_serial_options(self) -> dict:
+        """Returns a dictionary of options suitable for pyserial.Serial constructor."""
+        return {
+            "port": self.port,
+            "baudrate": self.baudrate,
+            "bytesize": self.bytesize,
+            "parity": self.parity,
+            "stopbits": self.stopbits,
+            "timeout": self.timeout,
+            "write_timeout": self.write_timeout,
+            "rtscts": self.rtscts,
+            "dsrdtr": self.dsrdtr,
+            "xonxoff": self.xonxoff,
+            "exclusive": self.exclusive,
+            # **self.serial_kwargs # If using advanced settings
+        }
+
+from .base import OutputHandler
+import time # For reconnect delays and send intervals
+import threading # For reconnection logic
+
+class SerialOutput(OutputHandler):
+    """Serial port output handler for NMEA sentences."""
+
+    def __init__(self, config: SerialOutputConfig):
+        """Initialize Serial output handler."""
+        super().__init__()
+        self.config = config
+        self.serial_port: Optional[serial.Serial] = None
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._reconnect_thread: Optional[threading.Thread] = None
+        self._last_send_time: float = 0.0
+
+    def start(self) -> None:
+        """Start the serial output handler."""
+        if self.is_running:
+            return
+
+        self._stop_event.clear()
+        print(f"Attempting to start serial output on {self.config.port} at {self.config.baudrate} baud.")
+        try:
+            self._connect()
+            self.is_running = True
+            self.start_time = time.time() # Record start time
+            print(f"Serial output started on {self.config.port}")
+        except serial.SerialException as e:
+            self.is_running = False
+            print(f"Failed to open serial port {self.config.port}: {e}")
+            # Optionally, start reconnection attempts if configured
+            if self.config.max_reconnect_attempts != 0:
+                 self._start_reconnect_thread()
+            # raise RuntimeError(f"Failed to start serial output: {e}") # Or handle more gracefully
+
+    def _connect(self) -> None:
+        """Establish serial connection."""
+        if self.serial_port and self.serial_port.is_open:
+            return # Already connected
+
+        try:
+            self.serial_port = serial.Serial(**self.config.get_serial_options())
+            # Ensure DTR/RTS are set if not using hardware flow control, some devices need them.
+            if not self.config.rtscts:
+                 self.serial_port.dtr = True
+                 self.serial_port.rts = True
+            print(f"Successfully connected to serial port {self.config.port}.")
+        except serial.SerialException as e:
+            print(f"Error connecting to {self.config.port}: {e}")
+            if self.serial_port:
+                self.serial_port.close()
+            self.serial_port = None
+            raise # Re-raise to be caught by start() or _reconnect_loop()
+
+    def stop(self) -> None:
+        """Stop the serial output handler."""
+        if not self.is_running and not (self._reconnect_thread and self._reconnect_thread.is_alive()):
+            return
+
+        print(f"Stopping serial output on {self.config.port}...")
+        self._stop_event.set()
+
+        if self._reconnect_thread and self._reconnect_thread.is_alive():
+            self._reconnect_thread.join(timeout=self.config.reconnect_delay + 1)
+            self._reconnect_thread = None
+
+        with self._lock:
+            if self.serial_port and self.serial_port.is_open:
+                try:
+                    self.serial_port.close()
+                    print(f"Serial port {self.config.port} closed.")
+                except Exception as e:
+                    print(f"Error closing serial port {self.config.port}: {e}")
+            self.serial_port = None
+
+        self.is_running = False
+        print("Serial output stopped.")
+
+    def send_sentence(self, sentence: str) -> bool:
+        """Send NMEA sentence to the serial port."""
+        if not self.is_running or not self.serial_port or not self.serial_port.is_open:
+            # If not running but trying to send, it could be due to a connection issue.
+            # Reconnection logic will handle this if enabled.
+            if not self.is_running and self.config.max_reconnect_attempts != 0 and not (self._reconnect_thread and self._reconnect_thread.is_alive()):
+                print("Serial port not connected. Attempting to reconnect...")
+                self._start_reconnect_thread() # Try to bring it back up
+            return False
+
+        with self._lock:
+            if not self.serial_port or not self.serial_port.is_open:
+                return False # Should be caught by the check above, but as a safeguard
+
+            # Enforce minimum send interval
+            current_time = time.time()
+            if current_time - self._last_send_time < self.config.send_interval:
+                time.sleep(self.config.send_interval - (current_time - self._last_send_time))
+
+            try:
+                full_sentence = sentence + self.config.line_ending
+                self.serial_port.write(full_sentence.encode('utf-8'))
+                self.serial_port.flush() # Ensure data is sent
+                self.sentences_sent += 1
+                self.last_sentence_time = time.time() # Record time of last successful send
+                self._last_send_time = time.time()
+                return True
+            except serial.SerialTimeoutException as e:
+                print(f"Serial write timeout on {self.config.port}: {e}")
+                self._handle_send_error()
+                return False
+            except serial.SerialException as e:
+                print(f"Serial error on {self.config.port} during send: {e}")
+                self._handle_send_error()
+                return False
+            except Exception as e:
+                print(f"Unexpected error sending data on {self.config.port}: {e}")
+                self._handle_send_error()
+                return False
+
+    def _handle_send_error(self):
+        """Handles errors during sending, potentially triggering reconnection."""
+        self.is_running = False # Mark as not running to stop further sends until reconnected
+        if self.serial_port:
+            try:
+                self.serial_port.close()
+            except Exception:
+                pass # Ignore errors during close if already in error state
+        self.serial_port = None
+
+        if not self._stop_event.is_set() and self.config.max_reconnect_attempts != 0:
+            print("Connection lost. Attempting to reconnect...")
+            self._start_reconnect_thread()
+
+    def _start_reconnect_thread(self):
+        """Starts the reconnection thread if not already running."""
+        with self._lock: # Protect access to _reconnect_thread
+            if not self._reconnect_thread or not self._reconnect_thread.is_alive():
+                self._reconnect_thread = threading.Thread(target=self._reconnect_loop, daemon=True)
+                self._reconnect_thread.start()
+                print("Reconnection thread started.")
+
+    def _reconnect_loop(self) -> None:
+        """Periodically attempts to reconnect to the serial port."""
+        attempts = 0
+        max_attempts = self.config.max_reconnect_attempts
+
+        while not self._stop_event.is_set() and \
+              (max_attempts == -1 or attempts < max_attempts):
+
+            if self.is_running: # Should not happen if called from error, but good check
+                break
+
+            attempts += 1
+            print(f"Reconnection attempt {attempts}/{max_attempts if max_attempts != -1 else 'infinite'} for {self.config.port}...")
+
+            try:
+                with self._lock: # Ensure exclusive access for connection attempt
+                    self._connect() # Try to connect
+                    self.is_running = True # If connect succeeds
+                    self.start_time = time.time()
+                    print(f"Successfully reconnected to {self.config.port}.")
+                # If successful, break the loop
+                break
+            except serial.SerialException as e:
+                print(f"Reconnect attempt {attempts} failed: {e}")
+                # Wait for the configured delay or until stop_event is set
+                self._stop_event.wait(self.config.reconnect_delay)
+            except Exception as e: # Catch any other unexpected errors during connect
+                print(f"Unexpected error during reconnect attempt {attempts}: {e}")
+                self._stop_event.wait(self.config.reconnect_delay)
+
+        if not self.is_running and not self._stop_event.is_set():
+            print(f"Failed to reconnect to {self.config.port} after {attempts} attempts. Stopping reconnection attempts.")
+        elif self._stop_event.is_set():
+             print("Reconnection attempts stopped by stop event.")
+
+        # Clean up the thread reference once done, if it was this thread
+        with self._lock:
+            if self._reconnect_thread == threading.current_thread():
+                 self._reconnect_thread = None
+                 print("Reconnection thread finished.")
+
+
+    def get_status(self) -> dict:
+        """Get serial output status."""
+        status = super().get_status()
+        with self._lock:
+            status.update({
+                'port': self.config.port,
+                'baudrate': self.config.baudrate,
+                'is_open': self.serial_port.is_open if self.serial_port else False,
+                'reconnecting': self._reconnect_thread.is_alive() if self._reconnect_thread else False,
+            })
+        return status
+
+    def __str__(self) -> str:
+        """String representation."""
+        state = "RUNNING" if self.is_running else "STOPPED"
+        if not self.is_running and self._reconnect_thread and self._reconnect_thread.is_alive():
+            state = "RECONNECTING"
+        details = f"{self.config.port}@{self.config.baudrate}bps"
+        return f"SerialOutput({state}, {details}, {self.sentences_sent} sentences)"
+
+    def __del__(self):
+        """Ensure resources are released."""
+        self.stop()

--- a/tests/test_serial_output.py
+++ b/tests/test_serial_output.py
@@ -1,0 +1,246 @@
+"""Tests for the SerialOutput handler."""
+
+import pytest
+import time
+import os
+import pty # For creating virtual serial ports (Unix-like specific)
+import serial # For reading from the virtual serial port
+
+from simulator.outputs.serial_output import SerialOutput, SerialOutputConfig
+from simulator.outputs.factory import OutputFactory
+from simulator.config.parser import ConfigParser, OutputConfig
+
+
+@pytest.fixture
+def virtual_serial_ports(scope="function"):
+    """Creates a virtual serial port pair using pty."""
+    master_fd, slave_fd = pty.openpty()
+    slave_name = os.ttyname(slave_fd)
+
+    # Configure the slave port to be non-blocking for reads
+    # This is important so that the test doesn't hang if data isn't immediately available.
+    # import fcntl
+    # flags = fcntl.fcntl(slave_fd, fcntl.F_GETFL)
+    # fcntl.fcntl(slave_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+    # Note: Making it non-blocking can be tricky with pty.
+    # For simplicity in this initial test, we might rely on timeouts or known data lengths.
+
+    print(f"Virtual serial port pair created: Master FD: {master_fd}, Slave: {slave_name} (FD: {slave_fd})")
+
+    yield slave_name, master_fd  # Slave name for SerialOutput, master_fd for test to read from
+
+    print("Closing virtual serial port pair...")
+    os.close(master_fd)
+    os.close(slave_fd)
+    print("Virtual serial ports closed.")
+
+
+@pytest.mark.skipif(not hasattr(pty, "openpty"), reason="pty module not available on this system (e.g., Windows)")
+class TestSerialOutput:
+
+    def test_serial_output_initialization(self, virtual_serial_ports):
+        """Test basic initialization of SerialOutput."""
+        slave_name, _ = virtual_serial_ports
+        config = SerialOutputConfig(port=slave_name, baudrate=9600, timeout=0.1, write_timeout=0.1)
+        handler = SerialOutput(config)
+        assert handler.config.port == slave_name
+        assert not handler.is_running
+        assert handler.serial_port is None
+
+    def test_serial_output_start_stop(self, virtual_serial_ports):
+        """Test starting and stopping SerialOutput."""
+        slave_name, _ = virtual_serial_ports
+        config = SerialOutputConfig(port=slave_name, baudrate=9600, timeout=0.1, write_timeout=0.1, max_reconnect_attempts=0)
+        handler = SerialOutput(config)
+
+        try:
+            handler.start()
+            assert handler.is_running
+            assert handler.serial_port is not None
+            assert handler.serial_port.is_open
+            assert handler.serial_port.port == slave_name
+        finally:
+            handler.stop()
+
+        assert not handler.is_running
+        # After stop, serial_port object might still exist but should be closed, or set to None
+        assert handler.serial_port is None or not handler.serial_port.is_open
+        # Check if the reconnect thread is cleaned up if it was ever started
+        assert handler._reconnect_thread is None or not handler._reconnect_thread.is_alive()
+
+
+    def test_serial_output_send_sentence(self, virtual_serial_ports):
+        """Test sending a sentence over SerialOutput."""
+        slave_name, master_fd = virtual_serial_ports
+        config = SerialOutputConfig(
+            port=slave_name,
+            baudrate=9600,
+            timeout=0.1,
+            write_timeout=0.1,
+            line_ending="\n", # Use simple newline for test reading
+            max_reconnect_attempts=0
+        )
+        handler = SerialOutput(config)
+        test_sentence = "$GPGGA,test_data*CHECKSUM"
+
+        try:
+            handler.start()
+            assert handler.is_running, "Handler should be running"
+
+            sent = handler.send_sentence(test_sentence)
+            assert sent, "send_sentence should return True on success"
+            assert handler.sentences_sent == 1
+
+            # Read from the master end of the pty
+            # This needs to be robust. The data might not arrive instantaneously.
+            # Set a timeout for the read operation.
+
+            # Create a serial object to read from the master_fd with appropriate settings
+            # This is a bit of a hack, as master_fd is not a typical serial device path.
+            # A more direct os.read might be better but can block.
+            # For pty, direct os.read is the way.
+
+            # Give some time for data to be written and available
+            time.sleep(0.2) # Increased sleep
+
+            # Read with a timeout (select can be used for non-blocking read with timeout on fd)
+            # For simplicity, let's try a direct read with a small buffer.
+            # This might be flaky if timing is off.
+            try:
+                # os.set_blocking(master_fd, False) # This might be needed
+                # Ensure master_fd is non-blocking for the read attempt to avoid hangs
+                # flags = fcntl.fcntl(master_fd, fcntl.F_GETFL)
+                # fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+                # This can be problematic as it changes global state of fd.
+                # A better approach is using select.select() to check for readability.
+                # For now, a simple read with a small timeout via select would be ideal,
+                # but os.read() itself doesn't directly support a timeout.
+                # We'll rely on the short sleep and hope the data is there.
+
+                received_data_bytes = os.read(master_fd, 1024) # Read up to 1024 bytes
+                # The sentence is sent with config.line_ending, which is "\n" for this test.
+                # os.read will get "$GPGGA,test_data*CHECKSUM\n"
+                # .strip() will remove the trailing "\n"
+                received_data = received_data_bytes.decode('utf-8').strip()
+                print(f"Received on master: '{received_data_bytes.decode('utf-8')}' -> Stripped: '{received_data}'") # Debug print
+                assert received_data == test_sentence
+            except BlockingIOError:
+                pytest.fail("Read from master_fd blocked or no data received in non-blocking mode.")
+            except Exception as e:
+                pytest.fail(f"Error reading from master_fd: {e}")
+
+        finally:
+            handler.stop()
+
+    def test_serial_config_parsing_and_factory(self, virtual_serial_ports):
+        """Test parsing serial config and creating handler via factory."""
+        slave_name, _ = virtual_serial_ports
+
+        # Minimal config data for serial
+        raw_config_data = {
+            'outputs': [
+                {
+                    'type': 'serial',
+                    'enabled': True,
+                    'port': slave_name,
+                    'baudrate': 19200,
+                    'timeout': 0.05, # 50ms
+                    'line_ending': "\r\n",
+                    'max_reconnect_attempts': 0
+                }
+            ]
+        }
+
+        # Use ConfigParser to parse this snippet
+        # We are interested in the OutputConfig part
+        parsed_sim_config = ConfigParser.from_dict(raw_config_data)
+        assert len(parsed_sim_config.output_configs) == 1
+
+        output_conf: OutputConfig = parsed_sim_config.output_configs[0]
+        assert output_conf.type == 'serial'
+        assert output_conf.enabled
+        assert isinstance(output_conf.config, SerialOutputConfig)
+        assert output_conf.config.port == slave_name
+        assert output_conf.config.baudrate == 19200
+        assert output_conf.config.timeout == 0.05
+        assert output_conf.config.line_ending == "\r\n"
+
+        # Test factory creation
+        handler = None
+        try:
+            handler = OutputFactory.create_output_handler(output_conf)
+            assert isinstance(handler, SerialOutput)
+            assert handler.config.port == slave_name
+            assert handler.config.baudrate == 19200
+
+            # Quick start/stop test
+            handler.start()
+            assert handler.is_running
+        finally:
+            if handler:
+                handler.stop()
+            assert handler is None or not handler.is_running
+
+    def test_serial_output_reconnection_logic_disabled(self, virtual_serial_ports):
+        """Test that reconnection is not attempted if max_reconnect_attempts is 0."""
+        invalid_port = "/dev/nonexistentport12345"
+        config = SerialOutputConfig(port=invalid_port, baudrate=9600, max_reconnect_attempts=0, reconnect_delay=0.1)
+        handler = SerialOutput(config)
+
+        handler.start() # This should fail to connect
+        assert not handler.is_running
+        assert handler.serial_port is None
+
+        # Give a very short time to see if a reconnect thread might have started (it shouldn't)
+        time.sleep(0.3)
+        assert handler._reconnect_thread is None or not handler._reconnect_thread.is_alive()
+        handler.stop() # Should be a no-op or clean up event
+
+    # More tests could be added:
+    # - Reconnection logic when enabled (mocking serial.Serial to fail and then succeed)
+    # - Different configurations (parity, stopbits, etc.) - harder to verify via pty without complex reader
+    # - Error handling during send (e.g., port disappears) - complex to simulate reliably
+
+# To run tests from CLI:
+# Ensure pyserial and pytest are installed.
+# In the project root:
+# python -m pytest tests/test_serial_output.py
+#
+# Note on pty:
+# The pty module creates a pseudo-terminal. The master end (master_fd) is what your test
+# uses to simulate the other side of the serial communication (e.g., a device reading NMEA data).
+# The slave end (identified by slave_name, e.g., /dev/pts/X) is what SerialOutput connects to.
+# Reading from master_fd can sometimes be tricky regarding blocking/non-blocking I/O and timing.
+# The current read in test_serial_output_send_sentence is basic and might need refinement
+# for robustness, e.g., using select.select for checking readability before os.read.
+#
+# For Windows, these tests relying on `pty` will be skipped. A different fixture
+# would be needed, potentially using a library like `com0com` (which requires prior setup)
+# or by extensively mocking `serial.Serial`.
+
+# Add a config for a test that expects failure to open port
+@pytest.mark.skipif(not hasattr(pty, "openpty"), reason="pty module not available on this system")
+def test_serial_output_start_failure_bad_port(capfd):
+    """Test SerialOutput start failure with a clearly invalid port name (not just non-existent)."""
+    # Using a port name that is syntactically invalid for pyserial on most systems,
+    # or one that pty wouldn't create.
+    # This test is more about pyserial raising an error that SerialOutput handles.
+    config = SerialOutputConfig(port="INVALID_PORT_!@#$", baudrate=9600, max_reconnect_attempts=0)
+    handler = SerialOutput(config)
+
+    handler.start() # Should attempt to connect, fail, and not start reconnect thread
+
+    assert not handler.is_running
+    assert handler.serial_port is None
+
+    # Check logs (optional, but good for diagnostics)
+    # captured = capfd.readouterr()
+    # assert "Failed to open serial port" in captured.out or "Error connecting to" in captured.out
+
+    handler.stop() # Should be clean
+
+    # Test with a port that might exist but we can't access (permission errors)
+    # This is harder to reliably test without specific environment setup.
+    # For now, focusing on non-existent and syntactically invalid.
+
+```


### PR DESCRIPTION
Implemented serial port output for NMEA sentences.

Key changes:
- Added `SerialOutputConfig` and `SerialOutput` classes in `simulator/outputs/serial_output.py` to handle serial communication using the `pyserial` library. This includes connection management, data sending, error handling, and a reconnection mechanism.
- Updated `simulator/config/parser.py` to parse 'serial' type configurations from YAML files into `SerialOutputConfig`.
- Updated `simulator/outputs/factory.py` to create `SerialOutput` instances.
- Added `pyserial` to `requirements.txt`.
- Included an example serial configuration in `config/network_config.yaml`.
- Added tests for the serial output functionality in `tests/test_serial_output.py`, using `pty` for virtual serial ports (tests skipped if `pty` is unavailable).
- Modified `simulator/outputs/base.py` to use `time.time()` for timestamps for consistency, affecting `OutputHandler`, `get_status`, and `reset_stats`.