### PR TITLE
fix: Standardize CRLF line endings for network and serial outputs

### DIFF
--- a/simulator/outputs/serial_output.py
+++ b/simulator/outputs/serial_output.py
@@ -175,7 +175,8 @@ class SerialOutput(OutputHandler):
                 time.sleep(self.config.send_interval - (current_time - self._last_send_time))
 
             try:
-                full_sentence = sentence + self.config.line_ending
+                # Strip sentence then append configured line ending
+                full_sentence = sentence.strip() + self.config.line_ending
                 self.serial_port.write(full_sentence.encode('utf-8'))
                 self.serial_port.flush() # Ensure data is sent
                 self.sentences_sent += 1

--- a/simulator/outputs/tcp.py
+++ b/simulator/outputs/tcp.py
@@ -32,10 +32,12 @@ class TCPClient:
         self.errors = 0
     
     def send_sentence(self, sentence: str, timeout: float = 5.0) -> bool:
-        """Send sentence to client."""
+        """Send sentence to client with CRLF line ending."""
         try:
             self.socket.settimeout(timeout)
-            self.socket.sendall(sentence.encode('utf-8'))
+            # Ensure sentence is stripped of existing newlines and terminated with CRLF
+            formatted_sentence = sentence.strip() + '\\r\\n'
+            self.socket.sendall(formatted_sentence.encode('utf-8'))
             self.sentences_sent += 1
             self.last_activity = time.time()
             return True

--- a/simulator/outputs/udp.py
+++ b/simulator/outputs/udp.py
@@ -89,7 +89,9 @@ class UDPOutput(OutputHandler):
             return False
         
         try:
-            sentence_bytes = sentence.encode('utf-8')
+            # Ensure sentence is stripped of existing newlines and terminated with CRLF
+            formatted_sentence = sentence.strip() + '\\r\\n'
+            sentence_bytes = formatted_sentence.encode('utf-8')
             sent_count = 0
             
             for address in self.target_addresses:


### PR DESCRIPTION
Ensures that all NMEA sentences sent via TCP, UDP, and Serial output handlers are consistently terminated with CRLF (\r\n).

Previously, these handlers sent sentence strings as received from the NMEA library, which could lead to inconsistent or missing line endings depending on the sentence type (e.g., GPS vs. AIS).

Changes:
- Modified simulator/outputs/tcp.py (TCPClient.send_sentence)
- Modified simulator/outputs/udp.py (UDPOutput.send_sentence)
- Modified simulator/outputs/serial_output.py (SerialOutput.send_sentence)

In each handler, the sentence string is now stripped of any existing leading/trailing whitespace or newlines, and then a CRLF sequence is appended before encoding and transmission. This adheres to common NMEA standards for these communication methods.